### PR TITLE
add 'Distinct' function

### DIFF
--- a/distinct.go
+++ b/distinct.go
@@ -1,0 +1,36 @@
+package jsonata
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Distinct - a function that you can pass an array of json objects through to remove exact duplicates
+func Distinct(input interface{}) ([]map[string]interface{}, error) {
+	if _, ok := input.([]map[string]interface{}); !ok {
+		return nil, fmt.Errorf("distinct can only be applied to an array of JSON objects")
+	}
+
+	jsonArray := input.([]map[string]interface{})
+
+	deduper := make(map[string]struct{})
+
+	output := make([]map[string]interface{}, 0)
+
+	for key := range jsonArray {
+		bytes, err := json.Marshal(jsonArray[key])
+		if err != nil {
+			return nil, err
+		}
+
+		blobStr := string(bytes)
+
+		if _, ok := deduper[blobStr]; !ok {
+			deduper[blobStr] = struct{}{}
+
+			output = append(output, jsonArray[key])
+		}
+	}
+
+	return output
+}

--- a/distinct.go
+++ b/distinct.go
@@ -6,16 +6,16 @@ import (
 )
 
 // Distinct - a function that you can pass an array of json objects through to remove exact duplicates
-func Distinct(input interface{}) ([]map[string]interface{}, error) {
-	if _, ok := input.([]map[string]interface{}); !ok {
+func Distinct(input interface{}) (interface{}, error) {
+	if _, ok := input.([]interface{}); !ok {
 		return nil, fmt.Errorf("distinct can only be applied to an array of JSON objects")
 	}
 
-	jsonArray := input.([]map[string]interface{})
+	jsonArray := input.([]interface{})
+
+	output := make([]interface{}, 0)
 
 	deduper := make(map[string]struct{})
-
-	output := make([]map[string]interface{}, 0)
 
 	for key := range jsonArray {
 		bytes, err := json.Marshal(jsonArray[key])
@@ -32,5 +32,5 @@ func Distinct(input interface{}) ([]map[string]interface{}, error) {
 		}
 	}
 
-	return output
+	return output, nil
 }

--- a/distinct_test.go
+++ b/distinct_test.go
@@ -1,0 +1,95 @@
+package jsonata
+
+import (
+	"testing"
+  "encoding/json"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+  jsonArr = `[
+  {
+    "code": "123141141",
+    "eans": [
+      {
+        "ean": 123124,
+        "name": "jim"
+      },
+      {
+        "ean": 123128,
+        "name": "juliet"
+      }
+    ]
+  },
+  {
+    "code": "123141141",
+    "eans": [
+      {
+        "ean": 123124,
+        "name": "jim"
+      },
+      {
+        "ean": 123128,
+        "name": "juliet"
+      }
+    ]
+  },
+  {
+    "code": "123142142",
+    "eans": {
+      "ean": 123124,
+      "name": "toby"
+    }
+  }
+]`
+  notArray = `{"i": "am not an array"}`
+)
+
+/*
+  the above array has two duplicate (unnecessary) objects
+  and the below method will produce a distinct output
+*/
+func Test_Distinct(t *testing.T) {
+  t.Run("an array of data with duplicates in it - will be made distinct", func(t *testing.T) {
+	var (
+		data               interface{}
+		expectedOutputData = []interface{}([]interface{}{map[string]interface{}{"code": "123141141",
+			"eans": []interface{}{map[string]interface{}{"ean": float64(123124), "name": "jim"},
+				map[string]interface{}{"ean": float64(123128), "name": "juliet"}}}, map[string]interface{}{"code": "123142142",
+			"eans": map[string]interface{}{"ean": float64(123124), "name": "toby"}}})
+	)
+
+	// Decode JSON.
+	err := json.Unmarshal([]byte(jsonArr), &data)
+	if err != nil {
+		t.Fail()
+	}
+
+	distinctData, err := Distinct(data)
+	if err != nil {
+    t.Fail()
+	}
+
+	assert.Equal(t, distinctData, expectedOutputData)
+  })
+
+  t.Run("NOT an array - error will be raised", func(t *testing.T) {
+    var (
+      data               interface{}
+    )
+  
+    // Decode JSON.
+    err := json.Unmarshal([]byte(notArray), &data)
+    if err != nil {
+      t.Fail()
+    }
+  
+    distinctData, err := Distinct(data)
+    if err == nil {
+      t.Fail()
+    }
+  
+    assert.Equal(t, distinctData, nil)
+    })
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/blues/jsonata-go
 
 go 1.16
+
+require github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This function will remove exact duplicate objects in a jsonata result. You can't _always_ use $distinct() where you want to (only on top level calls) so this is a go 'distinct' that you can run _after_ you've done jsonata work.

It's a simple function but saves people having to discover this themselves.

I figured this would be a useful function to embed in the go package - because then people can run it like this within go:

```
	e := jsonata.MustCompile("$sum(orders.(price*quantity))")

	// Evaluate.
	res, err := e.Eval(data)
	if err != nil {
		log.Fatal(err)
	}

        f, err := jsonata.Distinct(res)
	if err != nil {
		log.Fatal(err)
	}
        // f will be a distinct set of results
```

