### PR TITLE
Add 'Clean' function & decimal precision [from another fork]

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,5 +3,5 @@
 By participating in this project, you agree to abide by the
 [Blues Inc code of conduct][1].
 
-[1]: https://blues.github.io/opensource/code-of-conduct
+[1]: https://tbal999.github.io/opensource/code-of-conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-# Contributing to blues/jsonata-go
+# Contributing to tbal999/jsonata-go
 
 We love pull requests from everyone. By participating in this project, you
 agree to abide by the Blues Inc [code of conduct].
 
-[code of conduct]: https://blues.github.io/opensource/code-of-conduct
+[code of conduct]: https://tbal999.github.io/opensource/code-of-conduct
 
 Here are some ways *you* can contribute:
 
@@ -18,7 +18,7 @@ clean up inconsistent whitespace )
 * by closing [issues][]
 * by reviewing patches
 
-[issues]: https://github.com/blues/jsonata-go/issues
+[issues]: https://github.com/tbal999/jsonata-go/issues
 
 ## Submitting an Issue
 
@@ -55,7 +55,7 @@ clean up inconsistent whitespace )
 * If you don't know how to add tests, please put in a PR and leave a comment asking for help. 
 We love helping!
 
-[repo]: https://github.com/blues/jsonata-go/tree/master
+[repo]: https://github.com/tbal999/jsonata-go/tree/master
 [fork]: https://help.github.com/articles/fork-a-repo/
 [branch]:
 https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It currently has feature parity with jsonata-js 1.5.4. As well as a most of the 
 
 ## Install
 
-    go get github.com/blues/jsonata-go
+    go get github.com/tbal999/jsonata-go
 
 ## Usage
 
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"log"
 
-	jsonata "github.com/blues/jsonata-go"
+	jsonata "github.com/tbal999/jsonata-go"
 )
 
 const jsonString = `
@@ -56,7 +56,7 @@ func main() {
 
 ## JSONata Server
 A locally hosted version of [JSONata Exerciser](http://try.jsonata.org/)
-for testing is [available here](https://github.com/blues/jsonata-go/jsonata-server).
+for testing is [available here](https://github.com/tbal999/jsonata-go/jsonata-server).
 
 ## JSONata tests
 A CLI tool for running jsonata-go against the [JSONata test suite](https://github.com/jsonata-js/jsonata/tree/master/test/test-suite) is [available here](./jsonata-test).
@@ -67,7 +67,7 @@ A CLI tool for running jsonata-go against the [JSONata test suite](https://githu
 
 We love issues, fixes, and pull requests from everyone. Please run the
 unit-tests, staticcheck, and goimports prior to submitting your PR. By participating in this project, you agree to abide by
-the Blues Inc [code of conduct](https://blues.github.io/opensource/code-of-conduct).
+the Blues Inc [code of conduct](https://tbal999.github.io/opensource/code-of-conduct).
 
 For details on contributions we accept and the process for contributing, see our
 [contribution guide](CONTRIBUTING.md).

--- a/callable.go
+++ b/callable.go
@@ -11,9 +11,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jparse"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 type callableName struct {

--- a/callable_test.go
+++ b/callable_test.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blues/jsonata-go/jparse"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,7 @@
+package config
+
+var defaultDivisionPrecision int32 = 8
+
+func GetDivisionPrecision() int32 {
+	return defaultDivisionPrecision
+}

--- a/env.go
+++ b/env.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jparse"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 type environment struct {

--- a/error.go
+++ b/error.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 // ErrUndefined is returned by the evaluation methods when

--- a/eval.go
+++ b/eval.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/blues/jsonata-go/config"
+	"github.com/tbal999/jsonata-go/config"
 	"github.com/blues/jsonata-go/jlib"
 	"github.com/blues/jsonata-go/jparse"
 	"github.com/blues/jsonata-go/jtypes"

--- a/eval.go
+++ b/eval.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/tbal999/jsonata-go/config"
-	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/blues/jsonata-go/config"
+	"github.com/blues/jsonata-go/jlib"
 	"github.com/blues/jsonata-go/jparse"
 	"github.com/blues/jsonata-go/jtypes"
 	"github.com/shopspring/decimal"

--- a/eval.go
+++ b/eval.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 
 	"github.com/tbal999/jsonata-go/config"
-	"github.com/blues/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jlib"
 	"github.com/blues/jsonata-go/jparse"
 	"github.com/blues/jsonata-go/jtypes"
 	"github.com/shopspring/decimal"

--- a/eval.go
+++ b/eval.go
@@ -10,10 +10,10 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/blues/jsonata-go/config"
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jparse"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/config"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jtypes"
 	"github.com/shopspring/decimal"
 )
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jparse"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 type evalTestCase struct {

--- a/example_eval_test.go
+++ b/example_eval_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	jsonata "github.com/blues/jsonata-go"
+	jsonata "github.com/tbal999/jsonata-go"
 )
 
 const jsonString = `

--- a/example_exts_test.go
+++ b/example_exts_test.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"strings"
 
-	jsonata "github.com/blues/jsonata-go"
+	jsonata "github.com/tbal999/jsonata-go"
 )
 
 //

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,5 @@
 module github.com/blues/jsonata-go
 
-replace (
-    github.com/blues/jsonata-go => github.com/tbal999/jsonata-go
-)
-
 go 1.16
 
 require github.com/shopspring/decimal v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/blues/jsonata-go
 
 go 1.16
+
+require github.com/shopspring/decimal v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/blues/jsonata-go
 
+replace (
+    github.com/blues/jsonata-go => github.com/tbal999/jsonata-go
+)
+
 go 1.16
 
 require github.com/shopspring/decimal v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tbal999/jsonata-go
+module github.com/blues/jsonata-go
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/blues/jsonata-go
+module github.com/tbal999/jsonata-go
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/jlib/aggregate.go
+++ b/jlib/aggregate.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/blues/jsonata-go/config"
 	"github.com/blues/jsonata-go/jtypes"
+	"github.com/shopspring/decimal"
 )
 
 // Sum returns the total of an array of numbers. If the array is
@@ -24,17 +26,17 @@ func Sum(v reflect.Value) (float64, error) {
 
 	v = jtypes.Resolve(v)
 
-	var sum float64
+	var sum decimal.Decimal
 
 	for i := 0; i < v.Len(); i++ {
 		n, ok := jtypes.AsNumber(v.Index(i))
 		if !ok {
 			return 0, fmt.Errorf("cannot call sum on an array with non-number types")
 		}
-		sum += n
+		sum = sum.Add(decimal.NewFromFloat(n))
 	}
 
-	return sum, nil
+	return sum.RoundCeil(config.GetDivisionPrecision()).InexactFloat64(), nil
 }
 
 // Max returns the largest value in an array of numbers. If the
@@ -115,15 +117,15 @@ func Average(v reflect.Value) (float64, error) {
 		return 0, jtypes.ErrUndefined
 	}
 
-	var sum float64
+	var sum decimal.Decimal
 
 	for i := 0; i < v.Len(); i++ {
 		n, ok := jtypes.AsNumber(v.Index(i))
 		if !ok {
 			return 0, fmt.Errorf("cannot call average on an array with non-number types")
 		}
-		sum += n
+		sum = sum.Add(decimal.NewFromFloat(n))
 	}
 
-	return sum / float64(v.Len()), nil
+	return sum.Div(decimal.NewFromInt(int64(v.Len()))).RoundCeil(config.GetDivisionPrecision()).InexactFloat64(), nil
 }

--- a/jlib/aggregate.go
+++ b/jlib/aggregate.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/tbal999/jsonata-go/config"
+	"github.com/blues/jsonata-go/config"
 	"github.com/blues/jsonata-go/jtypes"
 	"github.com/shopspring/decimal"
 )

--- a/jlib/aggregate.go
+++ b/jlib/aggregate.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/blues/jsonata-go/config"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/config"
+	"github.com/tbal999/jsonata-go/jtypes"
 	"github.com/shopspring/decimal"
 )
 

--- a/jlib/aggregate.go
+++ b/jlib/aggregate.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/blues/jsonata-go/config"
+	"github.com/tbal999/jsonata-go/config"
 	"github.com/blues/jsonata-go/jtypes"
 	"github.com/shopspring/decimal"
 )

--- a/jlib/array.go
+++ b/jlib/array.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 // Count (golint)

--- a/jlib/boolean.go
+++ b/jlib/boolean.go
@@ -7,7 +7,7 @@ package jlib
 import (
 	"reflect"
 
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 // Boolean (golint)

--- a/jlib/date.go
+++ b/jlib/date.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/blues/jsonata-go/jlib/jxpath"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib/jxpath"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 // 2006-01-02T15:04:05.000Z07:00

--- a/jlib/date_test.go
+++ b/jlib/date_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 func TestFromMillis(t *testing.T) {

--- a/jlib/hof.go
+++ b/jlib/hof.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 // Map (golint)

--- a/jlib/jlib.go
+++ b/jlib/jlib.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 func init() {

--- a/jlib/number.go
+++ b/jlib/number.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 var reNumber = regexp.MustCompile(`^-?(([0-9]+))(\.[0-9]+)?([Ee][-+]?[0-9]+)?$`)

--- a/jlib/number_test.go
+++ b/jlib/number_test.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 func TestRound(t *testing.T) {

--- a/jlib/object.go
+++ b/jlib/object.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 // typeInterfaceMap is the reflect.Type for map[string]interface{}.

--- a/jlib/object_test.go
+++ b/jlib/object_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 type eachTest struct {

--- a/jlib/string.go
+++ b/jlib/string.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/blues/jsonata-go/jlib/jxpath"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib/jxpath"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 // String converts a JSONata value to a string. Values that are

--- a/jlib/string_test.go
+++ b/jlib/string_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 var typereplaceCallable = reflect.TypeOf((*replaceCallable)(nil)).Elem()

--- a/jparse/jparse_test.go
+++ b/jparse/jparse_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/blues/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jparse"
 )
 
 type testCase struct {

--- a/jsonata-server/README.md
+++ b/jsonata-server/README.md
@@ -1,11 +1,11 @@
 # JSONata Server
 
 A locally hosted version of [JSONata Exerciser](http://try.jsonata.org/)
-for testing [jsonata-go](https://github.com/blues/jsonata).
+for testing [jsonata-go](https://github.com/tbal999/jsonata).
 
 ## Install
 
-    go install github.com/blues/jsonata-go/jsonata-server
+    go install github.com/tbal999/jsonata-go/jsonata-server
 
 ## Usage
 

--- a/jsonata-server/bench.go
+++ b/jsonata-server/bench.go
@@ -10,7 +10,7 @@ import (
 
 	"encoding/json"
 
-	jsonata "github.com/blues/jsonata-go"
+	jsonata "github.com/tbal999/jsonata-go"
 )
 
 var (

--- a/jsonata-server/exts.go
+++ b/jsonata-server/exts.go
@@ -5,8 +5,8 @@
 package main
 
 import (
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 // Default format for dates: e.g. 2006-01-02 15:04 MST

--- a/jsonata-server/main.go
+++ b/jsonata-server/main.go
@@ -14,8 +14,8 @@ import (
 	_ "net/http/pprof"
 	"strings"
 
-	jsonata "github.com/blues/jsonata-go"
-	"github.com/blues/jsonata-go/jtypes"
+	jsonata "github.com/tbal999/jsonata-go"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 func init() {

--- a/jsonata-test/README.md
+++ b/jsonata-test/README.md
@@ -4,7 +4,7 @@ A CLI tool for running jsonata-go against the [JSONata test suite](https://githu
 
 ## Install
 
-    go install github.com/blues/jsonata-test
+    go install github.com/tbal999/jsonata-test
 
 ## Usage
 

--- a/jsonata-test/main.go
+++ b/jsonata-test/main.go
@@ -12,8 +12,8 @@ import (
 	"regexp"
 	"strings"
 
-	jsonata "github.com/blues/jsonata-go"
-	types "github.com/blues/jsonata-go/jtypes"
+	jsonata "github.com/tbal999/jsonata-go"
+	types "github.com/tbal999/jsonata-go/jtypes"
 )
 
 type testCase struct {

--- a/jsonata.go
+++ b/jsonata.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"regexp"
 
 	"github.com/tbal999/jsonata-go/jlib"
 	"github.com/blues/jsonata-go/jparse"

--- a/jsonata.go
+++ b/jsonata.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 	"unicode"
-	"regexp"
 
 	"github.com/blues/jsonata-go/jlib"
 	"github.com/blues/jsonata-go/jparse"
@@ -379,35 +378,4 @@ func isLetter(r rune) bool {
 
 func isDigit(r rune) bool {
 	return (r >= '0' && r <= '9') || unicode.IsDigit(r)
-}
-
-
-/* 
-	taken from the jsonata-test section and modified so that comments (like this one) can be written in the code
-	enables:
-	- comments in jsonata code
-	- fields with any character in their name i.e 'Field #' or "$ CURRENCY"
-*/
-
-var (
-	reQuotedPath      = regexp.MustCompile(`([A-Za-z\$\\*\` + "`" + `])\.[\"']([\s\S]+?)[\"']`)
-	reQuotedPathStart = regexp.MustCompile(`^[\"']([ \.0-9A-Za-z]+?)[\"']\.([A-Za-z\$\*\"\'])`)
-	commentsPath      = regexp.MustCompile(`\/\*([\s\S]*?)\*\/`)
-)
-
-// Clean - processes / cleans the jsonata query prior to being used in an Eval statement
-func Clean(s string) string {
-	if reQuotedPathStart.MatchString(s) {
-		s = reQuotedPathStart.ReplaceAllString(s, "`$1`.$2")
-	}
-
-	for reQuotedPath.MatchString(s) {
-		s = reQuotedPath.ReplaceAllString(s, "$1.`$2`")
-	}
-
-	for commentsPath.MatchString(s) {
-		s = commentsPath.ReplaceAllString(s, "")
-	}
-
-	return s
 }

--- a/jsonata.go
+++ b/jsonata.go
@@ -12,9 +12,9 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/blues/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jparse"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 var (

--- a/jsonata.go
+++ b/jsonata.go
@@ -13,9 +13,9 @@ import (
 	"unicode"
 	"regexp"
 
-	"github.com/tbal999/jsonata-go/jlib"
-	"github.com/tbal999/jsonata-go/jparse"
-	"github.com/tbal999/jsonata-go/jtypes"
+	"github.com/blues/jsonata-go/jlib"
+	"github.com/blues/jsonata-go/jparse"
+	"github.com/blues/jsonata-go/jtypes"
 )
 
 var (

--- a/jsonata.go
+++ b/jsonata.go
@@ -379,3 +379,34 @@ func isLetter(r rune) bool {
 func isDigit(r rune) bool {
 	return (r >= '0' && r <= '9') || unicode.IsDigit(r)
 }
+
+
+/* 
+	taken from the jsonata-test section and modified so that comments (like this one) can be written in the code
+	enables:
+	- comments in jsonata code
+	- fields with any character in their name i.e 'Field #' or "$ CURRENCY"
+*/
+
+var (
+	reQuotedPath      = regexp.MustCompile(`([A-Za-z\$\\*\` + "`" + `])\.[\"']([\s\S]+?)[\"']`)
+	reQuotedPathStart = regexp.MustCompile(`^[\"']([ \.0-9A-Za-z]+?)[\"']\.([A-Za-z\$\*\"\'])`)
+	commentsPath      = regexp.MustCompile(`\/\*([\s\S]*?)\*\/`)
+)
+
+// Clean - processes / cleans the jsonata query prior to being used in an Eval statement
+func Clean(s string) string {
+	if reQuotedPathStart.MatchString(s) {
+		s = reQuotedPathStart.ReplaceAllString(s, "`$1`.$2")
+	}
+
+	for reQuotedPath.MatchString(s) {
+		s = reQuotedPath.ReplaceAllString(s, "$1.`$2`")
+	}
+
+	for commentsPath.MatchString(s) {
+		s = commentsPath.ReplaceAllString(s, "")
+	}
+
+	return s
+}

--- a/jsonata.go
+++ b/jsonata.go
@@ -14,8 +14,8 @@ import (
 	"regexp"
 
 	"github.com/tbal999/jsonata-go/jlib"
-	"github.com/blues/jsonata-go/jparse"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 var (

--- a/jsonata.go
+++ b/jsonata.go
@@ -13,9 +13,12 @@ import (
 	"unicode"
 	"regexp"
 
-	"github.com/tbal999/jsonata-go/jlib"
-	"github.com/tbal999/jsonata-go/jparse"
-	"github.com/tbal999/jsonata-go/jtypes"
+
+	//"github.com/tbal999/jsonata-go/jlib"
+	//"github.com/tbal999/jsonata-go/jparse"
+	"github.com/blues/jsonata-go/jlib"
+	"github.com/blues/jsonata-go/jparse"
+	"github.com/blues/jsonata-go/jtypes"
 )
 
 var (

--- a/jsonata.go
+++ b/jsonata.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
-
+	"regexp"
 	"github.com/tbal999/jsonata-go/jlib"
 	"github.com/tbal999/jsonata-go/jparse"
 	"github.com/tbal999/jsonata-go/jtypes"

--- a/jsonata.go
+++ b/jsonata.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/blues/jsonata-go/jlib"
+	"github.com/tbal999/jsonata-go/jlib"
 	"github.com/blues/jsonata-go/jparse"
 	"github.com/blues/jsonata-go/jtypes"
 )

--- a/jsonata_test.go
+++ b/jsonata_test.go
@@ -19,8 +19,8 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/blues/jsonata-go/jparse"
-	"github.com/blues/jsonata-go/jtypes"
+	"github.com/tbal999/jsonata-go/jparse"
+	"github.com/tbal999/jsonata-go/jtypes"
 )
 
 type testCase struct {

--- a/jsonata_test.go
+++ b/jsonata_test.go
@@ -688,11 +688,11 @@ func TestNumericOperators(t *testing.T) {
 		},
 		{
 			Expression: "foo.bar / bar",
-			Output:     0.42857142857142855,
+			Output:     0.42857143,
 		},
 		{
 			Expression: "bar / foo.bar",
-			Output:     2.3333333333333335,
+			Output:     2.33333334,
 		},
 		{
 			Expression: "foo.bar % bar",
@@ -2308,17 +2308,17 @@ func TestObjectConstructor2(t *testing.T) {
 		{
 			Expression: "Account.Order{OrderID: $sum(Product.(Price*Quantity))}",
 			Output: map[string]interface{}{
-				"order103": 90.57000000000001,
-				"order104": 245.79000000000002,
+				"order103": 90.57,
+				"order104": 245.79,
 			},
 		},
 		{
 			Expression: "Account.Order.{OrderID: $sum(Product.(Price*Quantity))}",
 			Output: []interface{}{
 				map[string]interface{}{
-					"order103": 90.57000000000001,
+					"order103": 90.57,
 				}, map[string]interface{}{
-					"order104": 245.79000000000002,
+					"order104": 245.79,
 				},
 			},
 		},
@@ -2340,14 +2340,14 @@ func TestObjectConstructor2(t *testing.T) {
 				}`,
 			Output: map[string]interface{}{
 				"order103": map[string]interface{}{
-					"TotalPrice": 90.57000000000001,
+					"TotalPrice": 90.57,
 					"Items": []interface{}{
 						"Bowler Hat",
 						"Trilby hat",
 					},
 				},
 				"order104": map[string]interface{}{
-					"TotalPrice": 245.79000000000002,
+					"TotalPrice": 245.79,
 					"Items": []interface{}{
 						"Bowler Hat",
 						"Cloak",
@@ -2393,7 +2393,7 @@ func TestObjectConstructor2(t *testing.T) {
 								},
 							},
 						},
-						"Total Price": 90.57000000000001,
+						"Total Price": 90.57,
 					},
 					map[string]interface{}{
 						"ID": "order104",
@@ -2415,7 +2415,7 @@ func TestObjectConstructor2(t *testing.T) {
 								},
 							},
 						},
-						"Total Price": 245.79000000000002,
+						"Total Price": 245.79,
 					},
 				},
 			},
@@ -4004,16 +4004,16 @@ func TestFuncSum2(t *testing.T) {
 		{
 			Expression: "Account.Order.$sum(Product.(Price * Quantity))",
 			Output: []interface{}{
-				90.57000000000001,
-				245.79000000000002,
+				90.57,
+				245.79,
 			},
 		},
 		{
 			Expression: `Account.Order.(OrderID & ": " & $sum(Product.(Price*Quantity)))`,
 			Output: []interface{}{
 				// TODO: Why does jsonata-js only display to 2dp?
-				"order103: 90.57000000000001",
-				"order104: 245.79000000000002",
+				"order103: 90.57",
+				"order104: 245.79",
 			},
 		},
 		{
@@ -4293,16 +4293,16 @@ func TestFuncAverage2(t *testing.T) {
 		{
 			Expression: "Account.Order.$average(Product.(Price * Quantity))",
 			Output: []interface{}{
-				45.285000000000004,
-				122.89500000000001,
+				45.285,
+				122.895,
 			},
 		},
 		{
 			Expression: `Account.Order.(OrderID & ": " & $average(Product.(Price*Quantity)))`,
 			Output: []interface{}{
 				// TODO: Why does jsonata-js only display to 3dp?
-				"order103: 45.285000000000004",
-				"order104: 122.89500000000001",
+				"order103: 45.285",
+				"order104: 122.895",
 			},
 		},
 	})
@@ -5066,7 +5066,7 @@ func TestFuncString(t *testing.T) {
 		},
 		{
 			Expression: `$string(22/7)`,
-			Output:     "3.142857142857143", // TODO: jsonata-js returns "3.142857142857"
+			Output:     "3.14285715", // TODO: jsonata-js returns "3.142857142857"
 		},
 		{
 			Expression: `$string(1e100)`,
@@ -5176,8 +5176,8 @@ func TestFuncString2(t *testing.T) {
 			Expression: `Account.Order.$string($sum(Product.(Price* Quantity)))`,
 			// TODO: jsonata-js rounds to "90.57" and "245.79"
 			Output: []interface{}{
-				"90.57000000000001",
-				"245.79000000000002",
+				"90.57",
+				"245.79",
 			},
 		},
 	})


### PR DESCRIPTION
bit of code taken from the jsonata-test section and modified so that comments (like this one) can be written in the code
enables:

	- comments in jsonata code
	- fields with any character in their name i.e 'Field #' or "$ CURRENCY"

use case:

```
import (
	"encoding/json"
	"fmt"
	"log"

	jsonata "github.com/blues/jsonata-go"
)

const jsonString = `
    {
        "orders": [
            {"price": 10, "quantity": 3},
            {"price": 0.5, "quantity": 10},
            {"price": 100, "quantity": 1}
        ]
    }
`

func main() {

	var data interface{}

	// Decode JSON.
	err := json.Unmarshal([]byte(jsonString), &data)
	if err != nil {
		log.Fatal(err)
	}
	
	jsonataCode := "$sum(orders.(price*quantity)) /* this is an inline comment!*/"
	
	cleanCode := jsonata.Clean(jsonataCode)

	// Create expression.
	e := jsonata.MustCompile(cleanCode)

	// Evaluate.
	res, err := e.Eval(data)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println(res)
	// Output: 135
}
```