### PR TITLE
New thread-safe JSONata APIs

### DIFF
--- a/callable.go
+++ b/callable.go
@@ -86,6 +86,14 @@ type goCallable struct {
 	context          reflect.Value
 }
 
+// clone returns a shallow copy of the callable with cleared
+// per-call context to avoid sharing mutable state across goroutines.
+func (c *goCallable) clone() *goCallable {
+	cc := *c
+	cc.context = reflect.Value{}
+	return &cc
+}
+
 func newGoCallable(name string, ext Extension) (*goCallable, error) {
 
 	if err := validateGoCallableFunc(ext.Func); err != nil {

--- a/eval.go
+++ b/eval.go
@@ -913,8 +913,14 @@ func evalFunctionApplication(node *jparse.FunctionApplicationNode, data reflect.
 	// evaluate it.
 	if f, ok := node.RHS.(*jparse.FunctionCallNode); ok {
 
-		f.Args = append([]jparse.Node{node.LHS}, f.Args...)
-		return evalFunctionCall(f, data, env)
+		// Do not mutate the original AST node. Make a shallow copy
+		// and create a new args slice with LHS prepended.
+		g := *f
+		newArgs := make([]jparse.Node, 0, len(f.Args)+1)
+		newArgs = append(newArgs, node.LHS)
+		newArgs = append(newArgs, f.Args...)
+		g.Args = newArgs
+		return evalFunctionCall(&g, data, env)
 	}
 
 	// Evaluate both sides and return any errors.

--- a/jsonata_new.go
+++ b/jsonata_new.go
@@ -1,0 +1,192 @@
+// Copyright 2018 Blues Inc.  All rights reserved.
+// Use of this source code is governed by licenses granted by the
+// copyright holder including that found in the LICENSE file.
+
+package jsonata
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/blues/jsonata-go/jparse"
+)
+
+// CompiledExpression is an immutable, thread-safe compiled JSONata expression
+// that can spawn Evaluators.
+type CompiledExpression struct {
+	node         jparse.Node
+	baseRegistry map[string]reflect.Value
+}
+
+// CompileExpression parses a JSONata expression and returns a CompiledExpression
+// that can create Evaluators for execution.
+func CompileExpression(expr string) (*CompiledExpression, error) {
+
+	node, err := jparse.Parse(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	// No global registry in the new API by default.
+	return &CompiledExpression{node: node, baseRegistry: nil}, nil
+}
+
+// WithExts returns a new CompiledExpression with the provided extensions
+// merged into the base registry (copy-on-write). The original is unchanged.
+func (c *CompiledExpression) WithExts(exts map[string]Extension) (*CompiledExpression, error) {
+
+	values, err := processExts(exts)
+	if err != nil {
+		return nil, err
+	}
+
+	old := c.baseRegistry
+	newm := make(map[string]reflect.Value, len(old)+len(values))
+	for k, v := range old {
+		newm[k] = v
+	}
+	for k, v := range values {
+		newm[k] = v
+	}
+
+	return &CompiledExpression{
+		node:         c.node,
+		baseRegistry: newm,
+	}, nil
+}
+
+// WithVars returns a new CompiledExpression with the provided variables
+// merged into the base registry (copy-on-write). The original is unchanged.
+func (c *CompiledExpression) WithVars(vars map[string]interface{}) (*CompiledExpression, error) {
+
+	values, err := processVars(vars)
+	if err != nil {
+		return nil, err
+	}
+
+	old := c.baseRegistry
+	newm := make(map[string]reflect.Value, len(old)+len(values))
+	for k, v := range old {
+		newm[k] = v
+	}
+	for k, v := range values {
+		newm[k] = v
+	}
+
+	return &CompiledExpression{
+		node:         c.node,
+		baseRegistry: newm,
+	}, nil
+}
+
+// NewEvaluator creates a new Evaluator for this compiled expression.
+// Evaluators are intended to be used by a single goroutine.
+func (c *CompiledExpression) NewEvaluator() *Evaluator {
+	return &Evaluator{
+		expression: c,
+		extras:     make(map[string]reflect.Value),
+	}
+}
+
+// Evaluator executes a compiled expression. It can be configured with
+// per-evaluator variables and extensions via RegisterVars/RegisterExts.
+// Evaluator is not goroutine-safe; create one per goroutine.
+type Evaluator struct {
+	expression *CompiledExpression
+	extras     map[string]reflect.Value
+}
+
+// RegisterExts adds per-evaluator extensions. Not goroutine-safe.
+func (e *Evaluator) RegisterExts(exts map[string]Extension) error {
+	values, err := processExts(exts)
+	if err != nil {
+		return err
+	}
+	for k, v := range values {
+		e.extras[k] = v
+	}
+	return nil
+}
+
+// RegisterVars adds per-evaluator variables. Not goroutine-safe.
+func (e *Evaluator) RegisterVars(vars map[string]interface{}) error {
+	values, err := processVars(vars)
+	if err != nil {
+		return err
+	}
+	for k, v := range values {
+		e.extras[k] = v
+	}
+	return nil
+}
+
+// Eval evaluates the compiled expression with the provided input.
+func (e *Evaluator) Eval(data interface{}) (interface{}, error) {
+	input, ok := data.(reflect.Value)
+	if !ok {
+		input = reflect.ValueOf(data)
+	}
+
+	env := e.newEnv(input)
+	result, err := eval(e.expression.node, input, env)
+	if err != nil {
+		return nil, err
+	}
+
+	if !result.IsValid() {
+		return nil, ErrUndefined
+	}
+	if !result.CanInterface() {
+		return nil, err
+	}
+	if result.Kind() == reflect.Ptr && result.IsNil() {
+		return nil, nil
+	}
+	return result.Interface(), nil
+}
+
+func (e *Evaluator) newEnv(input reflect.Value) *environment {
+	tc := timeCallables(time.Now())
+
+	// Size hint: $ + time callables + base + extras
+	baseCount := len(e.expression.baseRegistry)
+	env := newEnvironment(baseEnv, 1+len(tc)+baseCount+len(e.extras))
+
+	env.bind("$", input)
+	env.bindAll(tc)
+
+	// Clone built-in callables from baseEnv into this evaluation environment
+	if baseEnv != nil && baseEnv.symbols != nil {
+		for name, v := range baseEnv.symbols {
+			if v.IsValid() && v.CanInterface() {
+				if gc, ok := v.Interface().(*goCallable); ok {
+					env.bind(name, reflect.ValueOf(gc.clone()))
+				}
+			}
+		}
+	}
+
+	// Bind base registry, cloning any goCallable
+	for name, v := range e.expression.baseRegistry {
+		if v.IsValid() && v.CanInterface() {
+			if gc, ok := v.Interface().(*goCallable); ok {
+				env.bind(name, reflect.ValueOf(gc.clone()))
+				continue
+			}
+		}
+		env.bind(name, v)
+	}
+
+	// Bind evaluator extras, cloning any goCallable
+	for name, v := range e.extras {
+		if v.IsValid() && v.CanInterface() {
+			if gc, ok := v.Interface().(*goCallable); ok {
+				env.bind(name, reflect.ValueOf(gc.clone()))
+				continue
+			}
+		}
+		env.bind(name, v)
+	}
+
+	return env
+}

--- a/jsonata_new_test.go
+++ b/jsonata_new_test.go
@@ -1,0 +1,94 @@
+package jsonata
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestCompileExpressionAndEval_Simple(t *testing.T) {
+	ce, err := CompileExpression("1+2")
+	if err != nil {
+		t.Fatalf("CompileExpression failed: %v", err)
+	}
+
+	ev := ce.NewEvaluator()
+	out, err := ev.Eval(nil)
+	if err != nil {
+		t.Fatalf("Eval failed: %v", err)
+	}
+
+	got, ok := out.(float64)
+	if !ok {
+		t.Fatalf("expected float64, got %T (%v)", out, out)
+	}
+	if got != 3 {
+		t.Fatalf("expected 3, got %v", got)
+	}
+}
+
+func TestCompiledExpression_WithExtsAndEval(t *testing.T) {
+	ce, err := CompileExpression("$twice(21)")
+	if err != nil {
+		t.Fatalf("CompileExpression failed: %v", err)
+	}
+
+	ce2, err := ce.WithExts(map[string]Extension{
+		"twice": {Func: func(x float64) float64 { return x * 2 }},
+	})
+	if err != nil {
+		t.Fatalf("WithExts failed: %v", err)
+	}
+
+	ev := ce2.NewEvaluator()
+	out, err := ev.Eval(nil)
+	if err != nil {
+		t.Fatalf("Eval failed: %v", err)
+	}
+	if out.(float64) != 42 {
+		t.Fatalf("expected 42, got %v", out)
+	}
+}
+
+func TestEvaluator_ConcurrentEval(t *testing.T) {
+	// Use a contextable builtin via function application to exercise per-call context.
+	ce, err := CompileExpression("'HelloWorld' ~> $substring(5, 5)")
+	if err != nil {
+		t.Fatalf("CompileExpression failed: %v", err)
+	}
+
+	const goroutines = 50
+	const iterations = 20
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines*iterations)
+	wg.Add(goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			ev := ce.NewEvaluator()
+			for i := 0; i < iterations; i++ {
+				out, err := ev.Eval(nil)
+				if err != nil {
+					errs <- err
+					return
+				}
+				// substring(5,5) on "HelloWorld" => "World"
+				if s, ok := out.(string); !ok || s != "World" {
+					errs <- fmt.Errorf("expected World, got %T (%v)", out, out)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent eval error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
**New APIs**
* CompileExpression → returns CompiledExpression (immutable, thread-safe)
* CompiledExpression.WithExts/WithVars → return new CompiledExpression via copy-on-write
* CompiledExpression.NewEvaluator → returns Evaluator (to be used in single-goroutine)
* Evaluator.RegisterExts/RegisterVars → per-evaluator additions
* Evaluator.Eval → evaluates with a fresh per-eval environment

**Thread-safety guarantees**
* CompiledExpression: immutable; safe to share across goroutines. WithExts/WithVars do copy-on-write and return new instances; concurrent calls are safe.
* Evaluator: not goroutine-safe; create one per goroutine. It’s safe to:
  * Create many Evaluators from the same CompiledExpression concurrently.
  * Call Eval concurrently across different Evaluators.
* Per-eval isolation:
  * Built-in and registered callables are shallow-cloned per evaluation; context injection happens on the clone, removing races on shared state.
  * Time-based callables are created per evaluation.
* Shared AST safety:
  * Function-application (~>) no longer mutates the parsed AST; the call node is copied before argument insertion. This enables concurrent evaluation of the same compiled expression across goroutines.

**What to avoid**
* If user-provided functions maintain their own internal mutable state outside JSONata’s goCallable, that state must be made thread-safe by the user.

**Legacy API (unchanged)**
* Existing Compile/Expr remain as-is for compatibility. The AST mutation fix benefits both APIs.